### PR TITLE
Do not require public-read acl

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -14,10 +14,10 @@ zip deploy/templates.zip ecs-blue-green-deployment.yaml templates/*
 cd scripts && zip scripts.zip * && cd ..
 mv scripts/scripts.zip deploy/scripts.zip
 
-aws s3 cp deploy/templates.zip "s3://${bucket}" --acl public-read
-aws s3 cp deploy/scripts.zip "s3://${bucket}" --acl public-read
-aws s3 cp ecs-blue-green-deployment.yaml "s3://${bucket}" --acl public-read
-aws s3 cp --recursive templates/ "s3://${bucket}/templates" --acl public-read
-aws s3 cp --recursive scripts/ "s3://${bucket}/scripts" --acl public-read
+aws s3 cp deploy/templates.zip "s3://${bucket}"
+aws s3 cp deploy/scripts.zip "s3://${bucket}"
+aws s3 cp ecs-blue-green-deployment.yaml "s3://${bucket}"
+aws s3 cp --recursive templates/ "s3://${bucket}/templates"
+aws s3 cp --recursive scripts/ "s3://${bucket}/scripts"
 aws s3api put-bucket-versioning --bucket "${bucket}" --versioning-configuration Status=Enabled
 aws cloudformation deploy --stack-name $stackname --template-file ecs-blue-green-deployment.yaml --capabilities CAPABILITY_NAMED_IAM --parameter-overrides GitHubUser=$GitHubUser GitHubToken=$GitHubToken TemplateBucket=$bucket

--- a/templates/deployment-pipeline.yaml
+++ b/templates/deployment-pipeline.yaml
@@ -117,7 +117,10 @@ Resources:
                   - ec2:*
                   - elasticloadbalancing:*
                   - autoscaling:*
-
+              - Resource: !Sub arn:aws:s3:::${TemplateBucket}/*
+                Effect: Allow
+                Action:
+                  - s3:GetObject
   CodeBuildServiceRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
*Issue:*
some companies do not allow the usage of public-read ACL for S3. In that case the bin/deploy `aws s3 cp <filename> <target-bucket> --acl public-read` will fail.

*Description of changes:*
This change removes the `--acl public-read`. To make sure cloudformation is still able to access the file in the s3 bucket  its execution role gets s3:GetObject permission on the template bucket.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
